### PR TITLE
change support page left nav title to sentence case

### DIFF
--- a/config/document-explorer-definition.yaml
+++ b/config/document-explorer-definition.yaml
@@ -71,7 +71,7 @@
       link: docs/release-notes/2022.md   
   - title: FAQ
     link: docs/FAQ.md
-  - title: Terms of Use
+  - title: Terms of use
     link: docs/terms-of-use.md
-  - title: Privacy Notice
+  - title: Privacy notice
     link: docs/privacy-notice.md


### PR DESCRIPTION
change /support left nav title to be sentence case for following: 

- Terms of Use
- Privacy Notice 

![image](https://github.com/user-attachments/assets/679caacb-575d-41d7-8d29-0b9d02b5c6d2)
